### PR TITLE
[#5] Feat: 마이 페이지 마크업 & 헤더 마크업

### DIFF
--- a/src/assets/index.css
+++ b/src/assets/index.css
@@ -27,7 +27,7 @@
   height: 10px;
   margin: 0 4px;
   cursor: pointer;
-  color: transparent;
+  color: black;
   border: 0;
   outline: 0;
   background: 0 0;
@@ -64,4 +64,41 @@
   border-radius: 30px;
   box-sizing: border-box;
   margin: 0 4px;
+}
+
+.mypage-dots {
+  position: relative;
+  right: -25%;
+}
+
+.mypage-dots li {
+  position: relative;
+  display: inline-block;
+  padding: 10px;
+  cursor: pointer;
+  box-sizing: border-box;
+}
+
+.mypage-dots li button {
+  background-color: #c8c7cc;
+  color: transparent;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+}
+
+.mypage-dots li.slick-active button {
+  width: 28px;
+  background-color: #2ac1bc;
+  border-radius: 30px;
+  box-sizing: border-box;
+  margin: 0 4px;
+}
+
+.likeItem {
+  background-color: antiquewhite;
+}
+
+.likeItem.slick-list {
+  width: 500px;
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,19 +1,23 @@
 import React, { useState } from 'react';
 import { AiOutlineMenu } from 'react-icons/ai';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { AiOutlineClose } from 'react-icons/ai';
 
 type Props = {};
 
 const Header = (props: Props) => {
   const [isOpen, setisOpen] = useState(false);
+  const navigate = useNavigate();
   const toggleMenu = () => {
     setisOpen((isOpen) => !isOpen);
   };
   if (!isOpen) {
     return (
       <div className='flex relative m-auto h-[100px] w-96 items-center justify-center'>
-        <div className='inset-x-0 top-0 text-cente'>
+        <div
+          className='inset-x-0 top-0 text-cente cursor-pointer'
+          onClick={() => navigate('/')}
+        >
           <span className='text-mw font-semibold'>MW </span>
           <span className='--black-100 font-light'>Loan</span>
         </div>

--- a/src/components/UserLoan/AccountHistory.tsx
+++ b/src/components/UserLoan/AccountHistory.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 type Props = {};
 
-const AccoutHistory = (props: Props) => {
+const AccountHistory = (props: Props) => {
   return (
     <div className='px-[20px] my-5'>
       <span>2023년 2월 14일</span>
@@ -31,4 +31,4 @@ const AccoutHistory = (props: Props) => {
   );
 };
 
-export default AccoutHistory;
+export default AccountHistory;

--- a/src/pages/MyPage/index.tsx
+++ b/src/pages/MyPage/index.tsx
@@ -13,11 +13,12 @@ const Mypage = (props: Props) => {
   const settings = {
     dots: true,
     slidesToShow: 3,
-    className: 'center',
-    centerPadding: '20px',
+    centerMode: true,
+    centerPadding: '60px',
+    arrows: false,
   };
   return (
-    <div className='mx-[60px]'>
+    <div className='mx-[60px] mb-[500px]'>
       <h1 className='text-[20px]'>
         <span className='text-mw font-bold'>미왕이</span> 님 안녕하세요!
       </h1>
@@ -30,7 +31,7 @@ const Mypage = (props: Props) => {
         </div>
       </div>
       <h2 className='text-[20px] font-bold my-[20px]'>관심 상품</h2>
-      <Slider {...settings}>
+      <Slider {...settings} dotsClass='mypage-dots' className='likeItem'>
         <LikeBox />
         <LikeBox />
         <LikeBox />

--- a/src/pages/UserLoanPage/index.tsx
+++ b/src/pages/UserLoanPage/index.tsx
@@ -1,10 +1,10 @@
 import React, { useState } from 'react';
 import AccountDetail from '../../components/UserLoan/AccountDetail';
-import AccoutHistory from '../../components/UserLoan/AccountHistory';
+import AccountHistory from '../../components/UserLoan/AccountHistory';
 
 type Props = {};
 
-const UserLonaPage = (props: Props) => {
+const UserLoanPage = (props: Props) => {
   const [menuChange, setMenuChange] = useState(false);
   const activeClassName = () => {
     return 'cursor-pointer text-mw font-bold border-solid border-mw border-b-4 text-[18px]';
@@ -15,8 +15,8 @@ const UserLonaPage = (props: Props) => {
 
   const accountHistory = () => (
     <>
-      <AccoutHistory />
-      <AccoutHistory />
+      <AccountHistory />
+      <AccountHistory />
     </>
   );
 
@@ -55,4 +55,4 @@ const UserLonaPage = (props: Props) => {
   );
 };
 
-export default UserLonaPage;
+export default UserLoanPage;


### PR DESCRIPTION
## 변경 사항

- 헤더 로고 클릭 시 메인으로 이동하게 변경
- 마이 페이지 > 이용 중인 대출 페이지 계좌 상세 컴포넌트 마크업
- 마이 페이지 메인에 있는 슬라이더 dots CSS 수정
